### PR TITLE
Release for v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.2.1](https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.2.0...v0.2.1) - 2024-02-23
+- Parsers for more locales are not implemented by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/5
+
 ## [v0.2.0](https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.1.1...v0.2.0) - 2024-02-21
 - Setting Locales by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-plugin-open-that-day",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Open daily note by natural language",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
This pull request is for the next release as v0.2.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Parsers for more locales are not implemented by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/5


**Full Changelog**: https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.2.0...v0.2.1