### PR TITLE
Release for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [v0.3.0](https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.2.1...v0.3.0) - 2024-03-11
+
+> [!WARNING]
+> This version has no data.json format compatibility with older versions.
+> Settings for enable/disable localed parser will be lost.
+
 - shorthand parser by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/7
 - Reorganize parsers by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.3.0](https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.2.1...v0.3.0) - 2024-03-11
+- shorthand parser by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/7
+- Reorganize parsers by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/9
+
 ## [v0.2.1](https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.2.0...v0.2.1) - 2024-02-23
 - Parsers for more locales are not implemented by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/5
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-plugin-open-that-day",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"description": "Open daily note by natural language",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
This pull request is for the next release as v0.3.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* shorthand parser by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/7
* Reorganize parsers by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/9


**Full Changelog**: https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.2.1...v0.3.0