### PR TITLE
Release for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v0.3.1](https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.3.0...v0.3.1) - 2024-05-01
+- update release workflow by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/10
+- chore(deps): bump actions/checkout from 3 to 4 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/12
+- chore(deps-dev): bump typescript from 4.7.4 to 5.4.5 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/13
+- chore(deps-dev): bump esbuild from 0.17.3 to 0.20.2 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/14
+- chore(deps-dev): bump @types/jest from 29.5.11 to 29.5.12 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/16
+- chore(deps-dev): bump builtin-modules from 3.3.0 to 4.0.0 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/17
+- chore(deps-dev): bump dayjs from 1.11.10 to 1.11.11 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/15
+- Run CI on GitHub Actions by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/18
+
 ## [v0.3.0](https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.2.1...v0.3.0) - 2024-03-11
 
 > [!WARNING]

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-plugin-open-that-day",
 	"name": "Open That Day",
-	"version": "0.1.0",
+	"version": "0.3.1",
 	"minAppVersion": "1.5.3",
 	"description": "Open daily note by natural language",
 	"author": "handlename",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-plugin-open-that-day",
 	"name": "Open That Day",
-	"version": "0.1.0",
+	"version": "0.3.1",
 	"minAppVersion": "1.5.3",
 	"description": "Open daily note by natural language",
 	"author": "handlename",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-plugin-open-that-day",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Open daily note by natural language",
 	"type": "module",
 	"engines": {


### PR DESCRIPTION
This pull request is for the next release as v0.3.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* update release workflow by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/10
* chore(deps): bump actions/checkout from 3 to 4 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/12
* chore(deps-dev): bump typescript from 4.7.4 to 5.4.5 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/13
* chore(deps-dev): bump esbuild from 0.17.3 to 0.20.2 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/14
* chore(deps-dev): bump @types/jest from 29.5.11 to 29.5.12 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/16
* chore(deps-dev): bump builtin-modules from 3.3.0 to 4.0.0 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/17
* chore(deps-dev): bump dayjs from 1.11.10 to 1.11.11 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/15
* Run CI on GitHub Actions by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/18

## New Contributors
* @dependabot made their first contribution in https://github.com/handlename/obsidian-plugin-open-that-day/pull/12

**Full Changelog**: https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.3.0...v0.3.1