### PR TITLE
Fix release name for BRAT

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -37,6 +37,6 @@
 #       Label of minor update targets. Default is [minor]
 #
 [tagpr]
-	vPrefix = true
+	vPrefix = false
 	releaseBranch = main
 	versionFile = package.json


### PR DESCRIPTION
BRAT expects version release without prefix "v"