### PR TITLE
Release for 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [0.3.3](https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.2...0.3.3) - 2024-05-01
+## [0.3.3](https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.3...0.3.3) - 2024-05-01
 - Follow tag pattern changing by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/21
 
-## [0.3.2](https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.3.1...0.3.2) - 2024-05-01
+## [0.3.3](https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.3.1...0.3.3) - 2024-05-01
 - Fix release name for BRAT by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/19
 
 ## [v0.3.1](https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.3.0...v0.3.1) - 2024-05-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.3.3](https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.2...0.3.3) - 2024-05-01
+- Follow tag pattern changing by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/21
+
 ## [0.3.2](https://github.com/handlename/obsidian-plugin-open-that-day/compare/v0.3.1...0.3.2) - 2024-05-01
 - Fix release name for BRAT by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/19
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-plugin-open-that-day",
 	"name": "Open That Day",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"minAppVersion": "1.5.3",
 	"description": "Open daily note by natural language",
 	"author": "handlename",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-plugin-open-that-day",
 	"name": "Open That Day",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"minAppVersion": "1.5.3",
 	"description": "Open daily note by natural language",
 	"author": "handlename",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-plugin-open-that-day",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"description": "Open daily note by natural language",
 	"type": "module",
 	"engines": {


### PR DESCRIPTION
This pull request is for the next release as 0.3.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.3.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.3.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Follow tag pattern changing by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/21


**Full Changelog**: https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.2...0.3.3