### PR TITLE
Release for 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.4](https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.3...0.3.4) - 2024-08-17
+- chore(deps-dev): bump tslib from 2.4.0 to 2.6.3 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/31
+- chore(deps-dev): bump ts-jest from 29.1.2 to 29.2.4 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/37
+- chore(deps-dev): bump obsidian from 1.4.11 to 1.6.6 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/34
+- chore(deps-dev): bump esbuild from 0.20.2 to 0.23.1 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/38
+- chore(deps-dev): bump @types/node from 20.11.7 to 22.4.0 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/39
+- braces v3.0.3 by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/40
+
 ## [0.3.3](https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.3...0.3.3) - 2024-05-01
 - Follow tag pattern changing by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/21
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-plugin-open-that-day",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"description": "Open daily note by natural language",
 	"type": "module",
 	"engines": {


### PR DESCRIPTION
This pull request is for the next release as 0.3.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.3.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.3.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps-dev): bump tslib from 2.4.0 to 2.6.3 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/31
* chore(deps-dev): bump ts-jest from 29.1.2 to 29.2.4 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/37
* chore(deps-dev): bump obsidian from 1.4.11 to 1.6.6 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/34
* chore(deps-dev): bump esbuild from 0.20.2 to 0.23.1 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/38
* chore(deps-dev): bump @types/node from 20.11.7 to 22.4.0 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/39
* braces v3.0.3 by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/40


**Full Changelog**: https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.3...0.3.4