### PR TITLE
Release for 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.5](https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.4...0.3.5) - 2025-01-06
+- chore(deps-dev): bump ts-jest from 29.2.4 to 29.2.5 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/42
+- chore(deps-dev): bump dayjs from 1.11.11 to 1.11.13 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/43
+- chore(deps): bump chrono-node from 2.7.5 to 2.7.7 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/46
+- chore(deps-dev): bump @types/node from 22.4.0 to 22.10.5 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/51
+- chore(deps-dev): bump tslib from 2.6.3 to 2.8.1 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/49
+- Nodejs version v20.18.0 by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/52
+
 ## [0.3.4](https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.3...0.3.4) - 2024-08-17
 - chore(deps-dev): bump tslib from 2.4.0 to 2.6.3 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/31
 - chore(deps-dev): bump ts-jest from 29.1.2 to 29.2.4 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/37

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-plugin-open-that-day",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"description": "Open daily note by natural language",
 	"type": "module",
 	"engines": {


### PR DESCRIPTION
This pull request is for the next release as 0.3.5 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.3.5 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.3.4" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps-dev): bump ts-jest from 29.2.4 to 29.2.5 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/42
* chore(deps-dev): bump dayjs from 1.11.11 to 1.11.13 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/43
* chore(deps): bump chrono-node from 2.7.5 to 2.7.7 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/46
* chore(deps-dev): bump @types/node from 22.4.0 to 22.10.5 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/51
* chore(deps-dev): bump tslib from 2.6.3 to 2.8.1 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/49
* Nodejs version v20.18.0 by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/52


**Full Changelog**: https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.4...0.3.5