### PR TITLE
Release for 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.6](https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.5...0.3.6) - 2025-01-06
+- Fix version in manifest.json by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/53
+- Fix release check trigger by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/55
+- Fix release check command by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/56
+
 ## [0.3.5](https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.4...0.3.5) - 2025-01-06
 - chore(deps-dev): bump ts-jest from 29.2.4 to 29.2.5 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/42
 - chore(deps-dev): bump dayjs from 1.11.11 to 1.11.13 by @dependabot in https://github.com/handlename/obsidian-plugin-open-that-day/pull/43

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-plugin-open-that-day",
 	"name": "Open That Day",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"minAppVersion": "1.5.3",
 	"description": "Open daily note by natural language",
 	"author": "handlename",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-plugin-open-that-day",
 	"name": "Open That Day",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"minAppVersion": "1.5.3",
 	"description": "Open daily note by natural language",
 	"author": "handlename",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-plugin-open-that-day",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"description": "Open daily note by natural language",
 	"type": "module",
 	"engines": {


### PR DESCRIPTION
This pull request is for the next release as 0.3.6 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag 0.3.6 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-0.3.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix version in manifest.json by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/53
* Fix release check trigger by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/55
* Fix release check command by @handlename in https://github.com/handlename/obsidian-plugin-open-that-day/pull/56


**Full Changelog**: https://github.com/handlename/obsidian-plugin-open-that-day/compare/0.3.5...0.3.6